### PR TITLE
Charge source can be a test card token

### DIFF
--- a/lib/stripe_mock/request_handlers/charges.rb
+++ b/lib/stripe_mock/request_handlers/charges.rb
@@ -19,6 +19,7 @@ module StripeMock
         end
 
         id = new_id('ch')
+        puts "NEW CHARGE #{id} w/ SOURCE #{params[:source]}"
 
         if params[:source]
           if params[:source].is_a?(String)
@@ -28,7 +29,11 @@ module StripeMock
             if params[:customer]
               params[:source] = get_card(customers[params[:customer]], params[:source])
             else
+
+              #puts "ADDING token"
+              #generate_card_token(params[:source])
               params[:source] = get_card_or_bank_by_token(params[:source])
+              #params[:source] = params[:source]
             end
           elsif params[:source][:id]
             raise Stripe::InvalidRequestError.new("Invalid token id: #{params[:source]}", 'card', http_status: 400)
@@ -40,6 +45,7 @@ module StripeMock
           end
         end
 
+        puts "ENSURE REQ. PARAMS"
         ensure_required_params(params)
         bal_trans_params = { amount: params[:amount], source: id }
 

--- a/lib/stripe_mock/request_handlers/charges.rb
+++ b/lib/stripe_mock/request_handlers/charges.rb
@@ -58,7 +58,6 @@ module StripeMock
           end
         end
 
-        puts "ENSURE REQ. PARAMS"
         ensure_required_params(params)
         bal_trans_params = { amount: params[:amount], source: id }
 

--- a/lib/stripe_mock/request_handlers/helpers/token_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/token_helpers.rb
@@ -36,7 +36,8 @@ module StripeMock
 
       def get_card_or_bank_by_token(token)
         token_id = token['id'] || token
-         @card_tokens[token_id] || @bank_tokens[token_id] || raise(Stripe::InvalidRequestError.new("Invalid token id: #{token_id}", 'tok', http_status: 404))
+        puts "GET CARD OR BANK BY TOKEN #{token_id}"
+        @card_tokens[token_id] || @bank_tokens[token_id] || raise(Stripe::InvalidRequestError.new("Invalid token id: #{token_id}", 'tok', http_status: 404))
       end
 
     end

--- a/lib/stripe_mock/request_handlers/helpers/token_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/token_helpers.rb
@@ -10,11 +10,9 @@ module StripeMock
       end
 
       def generate_card_token(card_params = {})
-        puts "GENERATING CARD TOKEN"
         token = new_id 'tok'
         card_params[:id] = new_id 'cc'
         @card_tokens[token] = Data.mock_card symbolize_names(card_params)
-        puts @card_tokens.count
         token
       end
 

--- a/lib/stripe_mock/request_handlers/helpers/token_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/token_helpers.rb
@@ -10,9 +10,11 @@ module StripeMock
       end
 
       def generate_card_token(card_params = {})
+        puts "GENERATING CARD TOKEN"
         token = new_id 'tok'
         card_params[:id] = new_id 'cc'
         @card_tokens[token] = Data.mock_card symbolize_names(card_params)
+        puts @card_tokens.count
         token
       end
 
@@ -36,7 +38,6 @@ module StripeMock
 
       def get_card_or_bank_by_token(token)
         token_id = token['id'] || token
-        puts "GET CARD OR BANK BY TOKEN #{token_id}"
         @card_tokens[token_id] || @bank_tokens[token_id] || raise(Stripe::InvalidRequestError.new("Invalid token id: #{token_id}", 'tok', http_status: 404))
       end
 

--- a/lib/stripe_mock/version.rb
+++ b/lib/stripe_mock/version.rb
@@ -1,4 +1,4 @@
 module StripeMock
   # stripe-ruby-mock version
-  VERSION = "2.5.5"
+  VERSION = "2.5.6"
 end

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -4,8 +4,8 @@ shared_examples 'Charge API' do
   let(:charge_attrs) { {
     amount: 1995,
     currency: "usd",
-    source: "tok_amex"
-    #source: StripeMock.generate_card_token
+    #source: "tok_amex"
+    source: StripeMock.generate_card_token
   } }
   let(:charge) { Stripe::Charge.create(charge_attrs) }
 
@@ -20,7 +20,7 @@ shared_examples 'Charge API' do
   end
 
   it "accepts a valid card token", :live => true do
-    expect(charge.source).to eql("tok_amex")
+    expect(charge.source).to be_kind_of(Stripe::Card)
   end
 
   it "requires a valid customer or source", :live => true do

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 shared_examples 'Charge API' do
+  let(:charge_attrs) { {
+    amount: 1995,
+    currency: "usd",
+    source: "tok_amex"
+    #source: StripeMock.generate_card_token
+  } }
+  let(:charge) { Stripe::Charge.create(charge_attrs) }
 
   it "requires a valid card token", :live => true do
     expect {
@@ -10,6 +17,10 @@ shared_examples 'Charge API' do
         source: 'bogus_card_token'
       )
     }.to raise_error(Stripe::InvalidRequestError, /token/i)
+  end
+
+  it "accepts a valid card token", :live => true do
+    expect(charge.source).to eql("tok_amex")
   end
 
   it "requires a valid customer or source", :live => true do

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -1,13 +1,6 @@
 require 'spec_helper'
 
 shared_examples 'Charge API' do
-  let(:charge_attrs) { {
-    amount: 1995,
-    currency: "usd",
-    #source: "tok_amex"
-    source: StripeMock.generate_card_token
-  } }
-  let(:charge) { Stripe::Charge.create(charge_attrs) }
 
   it "requires a valid card token", :live => true do
     expect {
@@ -19,7 +12,9 @@ shared_examples 'Charge API' do
     }.to raise_error(Stripe::InvalidRequestError, /token/i)
   end
 
-  it "accepts a valid card token", :live => true do
+  it "accepts a supported test card token", :live => true do
+    charge_attrs = {amount: 1995, currency: "usd", source: "tok_amex"}
+    charge = Stripe::Charge.create(charge_attrs)
     expect(charge.source).to be_kind_of(Stripe::Card)
   end
 


### PR DESCRIPTION
The client should be able to create a `Stripe::Charge` using one of the [recognized testing tokens](https://stripe.com/docs/testing#cards) (i.e. `"tok_amex"`). But currently it throws `Stripe::InvalidRequestError: Invalid token id: tok_visa`.